### PR TITLE
Fix app for case sensitive file systems

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,7 +19,7 @@ request({
             let url = $( this ).find('a').find('img').attr('src').split('?')[0]
             emojis.push({
                 url: url,
-                dest: "Emojis/" + folder
+                dest: "emojis/" + folder
             })
         })
     })


### PR DESCRIPTION
typo (uppercase instead of lower case)
This breaks the app on *nix system using case sensitive file systems by default